### PR TITLE
migration fix and testing fix

### DIFF
--- a/db/migrate/20240904020401_create_posters.rb
+++ b/db/migrate/20240904020401_create_posters.rb
@@ -5,8 +5,7 @@ class CreatePosters < ActiveRecord::Migration[7.1]
       t.string :description
       t.float :price
       t.integer :year
-      t.string :vintage
-      t.string :boolean
+      t.boolean :vintage
       t.string :img_url
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_020401) do
     t.string "description"
     t.float "price"
     t.integer "year"
-    t.string "vintage"
-    t.string "boolean"
+    t.boolean "vintage"
     t.string "img_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/requests/api/v1/poster_request_spec.rb
+++ b/spec/requests/api/v1/poster_request_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe "Posters" do
       expect(attributes[:year]).to be_an(Integer)
 
       expect(attributes).to have_key(:vintage)
-
-      # expect(attributes[:vintage]).to be_in([true, false])
+      expect(attributes[:vintage]).to be_in([true, false])
 
       expect(attributes).to have_key(:img_url)
       expect(attributes[:img_url]).to be_a(String)
@@ -75,8 +74,7 @@ RSpec.describe "Posters" do
       expect(attributes[:year]).to be_an(Integer)
 
       expect(attributes).to have_key(:vintage)
-
-      # expect(attributes[:vintage]).to be_in([true, false])
+      expect(attributes[:vintage]).to be_in([true, false])
 
       expect(attributes).to have_key(:img_url)
       expect(attributes[:img_url]).to be_a(String)


### PR DESCRIPTION
This PR fixes some problems with the migration: changes vintage to be a boolean and removes the boolean attribute.

This also replace the temporary tests with the actual passing tests.